### PR TITLE
bl: rm credoweb, rv [[Special:Diff/8319921]], ref [[Special:Diff/11107566]]

### DIFF
--- a/Spam-blacklist
+++ b/Spam-blacklist
@@ -109,9 +109,6 @@
 # Owned by the wikipedia.bg domain cybersquatter - Dimitar Mihaylov Tashev
 \bcmtbg\.com\b
 
-# [[Специални:Приноси/85.239.131.109]]
-\bcredoweb\.bg\b
-
 
 ### D ###
 


### PR DESCRIPTION
https://bg.wikipedia.org/w/index.php?diff=11107566&oldid=11107564&diffmode=source

Имало е спамър през 2017. Мисля, че можем да го махнем изцяло. При нужда ще го добавим пак.

https://bg.wikipedia.org/w/index.php?diff=8319921&diffmode=source
https://bg.wikipedia.org/wiki/Special:Contributions/85.239.131.109